### PR TITLE
Updates to improve script reliability

### DIFF
--- a/Webbie/InstallScripts/nmpanel_update.sh
+++ b/Webbie/InstallScripts/nmpanel_update.sh
@@ -3,42 +3,67 @@
 # Execute this script with sudo!
 #
 #
+
+######
+#
+# Environmental Variables for the script
+#
+# You shouldn't need or want to change these
+#
+# Path to temp directory
+WEBBIE_TEMP_DIR=/tmp
+#
+# Webbie Download Path
+WEBBIE_DOWNLOAD_PATH=$WEBBIE_TEMP_DIR/webbie.zip
+#
+######
+
+#################################### === DO NOT CHANGE ANYTHING UNDER HERE - YOU WILL PROBABLY BREAK SOMETHING === #################################### 
+
 read -p 'Set Web Directory (Example: /var/www/html/networkmanager) ' directory
 read -p 'Copy the download link of the NetworkManager file in Discord  ' downloadlink
 
-if curl --output /dev/null --silent --head --fail "$downloadlink"
+echo "Attempting to download the file"
+wget -O $WEBBIE_DOWNLOAD_PATH $downloadlink
+
+if test -f $WEBBIE_DOWNLOAD_PATH;
 then
 	if [ ! -z "$directory" ]
 	then
 		echo "Starting updating the panel..."
-		cd /tmp
-		wget -O webbie.zip $downloadlink
-		mv $directory/protected/config.ini /tmp
-		mv $directory/protected/settings.json /tmp
-		mv $directory/inc/php/dep/languages /tmp
-		mv $directory/inc/img /tmp
-		mv $directory/addons /tmp
+		cd $WEBBIE_TEMP_DIR
+		mv $directory/protected/config.ini $WEBBIE_TEMP_DIR
+		mv $directory/protected/settings.json $WEBBIE_TEMP_DIR
+		mv $directory/inc/php/dep/languages $WEBBIE_TEMP_DIR
+		mv $directory/inc/img $WEBBIE_TEMP_DIR
+		mv $directory/addons $WEBBIE_TEMP_DIR
 		rm -rf $directory
-		mkdir $directory
-		unzip /tmp/webbie.zip -d $directory
+		mkdir -p $directory
+		unzip $WEBBIE_DOWNLOAD_PATH -d $directory
 		rm $directory/install.php
 		rm $directory/install_data.php
 		rm -rf $directory/inc/php/dep/languages
 		rm -rf $directory/inc/img
 		rm -rf $directory/addons
-		mv /tmp/config.ini $directory/protected
-		mv /tmp/settings.json $directory/protected
-		mv /tmp/languages $directory/inc/php/dep
-		mv /tmp/img $directory/inc
-		mv /tmp/addons $directory
+		mv $WEBBIE_TEMP_DIR/config.ini $directory/protected
+		mv $WEBBIE_TEMP_DIR/settings.json $directory/protected
+		mv $WEBBIE_TEMP_DIR/languages $directory/inc/php/dep
+		mv $WEBBIE_TEMP_DIR/img $directory/inc
+		mv $WEBBIE_TEMP_DIR/addons $directory
 		chmod 664 $directory/protected/config.ini
 		chmod 777 $directory/protected/settings.json
 		chmod 777 -R $directory/inc/php/dep/languages
 		chmod 755 -R $directory/inc/img
-		echo "Update complete."
+		echo "Update complete. Cleaning up downloaded file"
+		rm -f $WEBBIE_DOWNLOAD_PATH
+		exit 0
 	else
-		echo "No panel location has been given. Updating the panel has failed."
+		echo "No panel location has been given. Updating the panel has failed. Cleaning up download"
+		rm -f $WEBBIE_DOWNLOAD_PATH
+		exit 1
 	fi
 else
-    echo "This URL does not exist. Updating the panel has failed."
+    echo "This URL is invalid or does not exist. Updating the panel has failed. Running cleanup..."
+    rm -f $WEBBIE_DOWNLOAD_PATH
+    exit 1
 fi


### PR DESCRIPTION
This should just make the process a bit easier for users, and make the script a bit more flexible, some OS's don't like people doing stuff in /tmp for one thing, but this also means the file will be downloaded, and only if it fails to download it will fail the script whereas before that wasn't the case.